### PR TITLE
fix(task01/main.cpp): ci for MSBuild

### DIFF
--- a/task01/main.cpp
+++ b/task01/main.cpp
@@ -3,6 +3,8 @@
 #include <cassert>
 #include <vector>
 #include <filesystem>
+#define _USE_MATH_DEFINES
+#include <cmath>
 //
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"


### PR DESCRIPTION
Hi, I am opening this pull request to fix the CI error is MSBuild workflows. It is just a trivial fix.

According to MSBuild Document, we have to define the marco `_USE_MATH_DEFINES` to use the constants in `<cmath.h>`. Link is [here](https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170&redirectedfrom=MSDN).
And I think it would be better for the template code to include this marco, it is a little bit confusing for people on other platform when they are using constants in cmath, because they can run their code on their local machine but they will encounter error in CI. And this fix can help people avoid that situation.

Log of pervious CI encountering error: [log](https://github.com/ACG-2024S/acg-SunskyXH/actions/runs/8682313352/job/23806631089)
Log after fix: [log](https://github.com/ACG-2024S/acg-SunskyXH/actions/runs/8682480395/job/23807060205)

ps: only people with read permission of my GitHub classroom repo can view the log.